### PR TITLE
fix caching in ex4_text.load_nips_TSTData

### DIFF
--- a/freqopttest/ex/ex4_text.py
+++ b/freqopttest/ex/ex4_text.py
@@ -274,8 +274,9 @@ def load_nips_TSTData(fname):
     X = X[:n_min, :]
     Y = Y[:n_min, :]
     assert(X.shape[0] == Y.shape[0])
-    cache_loaded[fname] = (loaded, n_min)
-    return data.TSTData(X, Y), n_min
+    tst_data = data.TSTData(X, Y)
+    cache_loaded[fname] = (tst_data, n_min)
+    return tst_data, n_min
 
 def get_sample_source(prob_label):
     """Return a (SampleSource, n) representing the problem"""


### PR DESCRIPTION
Thanks for publishing your code / experiments!

The caching in `ex4_text.load_nips_TSTData` is apparently broken. This change seems to fix it for me.

```
i: 39, lamb:  2.19, gwidth: 5.06e+05, power: 0.1365
INFO: 2016-08-17 19:43:50,885: ex4_text.compute(): done. ex4: job_met_gwgrid, r=0
Traceback (most recent call last):
  File "/usr/local/anaconda/envs/py2/lib/python2.7/pdb.py", line 1314, in main
    pdb._runscript(mainpyfile)
  File "/usr/local/anaconda/envs/py2/lib/python2.7/pdb.py", line 1233, in _runscript
    self.run(statement)
  File "/usr/local/anaconda/envs/py2/lib/python2.7/bdb.py", line 400, in run
    exec cmd in globals, locals
  File "<string>", line 1, in <module>
  File "ex4_text.py", line 3, in <module>
    """
  File "ex4_text.py", line 295, in main
    run_dataset(prob_label)
  File "ex4_text.py", line 339, in run_dataset
    agg = engine.submit_job(job)
  File "/Users/dougal/misc/independent-jobs/independent_jobs/engines/SerialComputationEngine.py", line 10, in submit_job
    job.compute()
  File "/Users/dougal/misc/interpretable-test/freqopttest/ex/ex4_text.py", line 195, in compute
    d = sample_source.dim()
  File "/Users/dougal/misc/interpretable-test/freqopttest/data.py", line 51, in dim
    return self.tst_data.dim()
AttributeError: 'dict' object has no attribute 'dim'
```
